### PR TITLE
Refactor the example using new Notification struct defination

### DIFF
--- a/example/sendmsg.go
+++ b/example/sendmsg.go
@@ -19,21 +19,23 @@ func main() {
 	r := rand.New(rand.NewSource(time.Now().Unix()))
 
 	notification := goapns.Notification{}
-	notification.Device_token = "YOUR_DEVICE_TOKEN"
-	notification.Alert = "hello world! 0"
+	notification.DeviceToken = "YOUR_DEVICE_TOKEN"
+	notification.Aps = goapns.SimpleAps{
+		Alert: "hello world! 0",
+	}
 	notification.Identifier = r.Uint32()
 	err = apn.SendNotification(&notification)
 	fmt.Println(err)
 
-	notification.Alert = "hello world! 1"
+	notification.Aps.Alert = "hello world! 1"
 	err = apn.SendNotification(&notification)
 	fmt.Println(err)
 
-	notification.Alert = "hello world! 2"
+	notification.Aps.Alert = "hello world! 2"
 	err = apn.SendNotification(&notification)
 	fmt.Println(err)
 
-	notification.Alert = "hello world! 3"
+	notification.Aps.Alert = "hello world! 3"
 	err = apn.SendNotification(&notification)
 	fmt.Println(err)
 	time.Sleep(5E9)


### PR DESCRIPTION
Last change we moved Notification.Alert to Notification.Aps.Alert, but the example code still using the old struct defination. This change is to fix this issue.
